### PR TITLE
Add optional yara scanning to log2timeline and psort workers

### DIFF
--- a/src/log2timeline.py
+++ b/src/log2timeline.py
@@ -54,7 +54,7 @@ TASK_NAME = "openrelik-worker-plaso.tasks.log2timeline"
 
 # Task metadata for registration in the core system.
 TASK_METADATA = {
-    "display_name": "Plaso: Log2Timeline2",
+    "display_name": "Plaso: Log2Timeline",
     "description": "Super timelining",
     "task_config": [
         {

--- a/src/log2timeline.py
+++ b/src/log2timeline.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import os
 import shutil
 import subprocess
@@ -22,7 +23,6 @@ from openrelik_worker_common.task_utils import (
     create_task_result,
     get_input_files,
 )
-
 from plaso import __version__ as plaso_version
 from plaso.cli import pinfo_tool
 from plaso.cli.extraction_tool import ExtractionTool
@@ -30,6 +30,9 @@ from plaso.parsers import manager
 
 from .app import celery
 from .utils import log2timeline_status_to_dict
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # Get all Plaso parser names to use for user config form.
 parser_manager = manager.ParsersManager()
@@ -51,7 +54,7 @@ TASK_NAME = "openrelik-worker-plaso.tasks.log2timeline"
 
 # Task metadata for registration in the core system.
 TASK_METADATA = {
-    "display_name": "Plaso: Log2Timeline",
+    "display_name": "Plaso: Log2Timeline2",
     "description": "Super timelining",
     "task_config": [
         {
@@ -75,6 +78,13 @@ TASK_METADATA = {
             "description": "Select one or more Plaso archive types. Files inside these archive types will be processed.",
             "type": "autocomplete",
             "items": archive_names,
+            "required": False,
+        },
+        {
+            "name": "Yara rules",
+            "label": "Yara rules",
+            "description": "Add Yara rules to tag files with.",
+            "type": "textarea",
             "required": False,
         },
     ],
@@ -135,6 +145,16 @@ def log2timeline(
     if task_config and task_config.get("archives"):
         command.extend(["--archives", ",".join(task_config["archives"])])
 
+    if task_config and task_config.get("Yara rules"):
+        yara_rules_file = create_output_file(
+            output_path,
+            extension="yara",
+            data_type="plaso:log2timeline:yara_rules",
+        )
+        with open(yara_rules_file.path, "w") as f:
+            f.write(task_config["Yara rules"])
+        command.extend(["--yara_rules", yara_rules_file.path])
+
     command_string = " ".join(command)
 
     if len(input_files) > 1:
@@ -149,6 +169,8 @@ def log2timeline(
         command.append(temp_dir)
     else:
         command.append(input_files[0].get("path"))
+
+    logging.info(f"Running command: {' '.join(command)}")
 
     process = subprocess.Popen(command)
     while process.poll() is None:

--- a/src/psort.py
+++ b/src/psort.py
@@ -21,6 +21,11 @@ from openrelik_worker_common.task_utils import create_task_result, get_input_fil
 from .app import celery
 from .utils import log2timeline_status_to_dict
 
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 # Task name used to register and route the task to the correct queue.
 TASK_NAME = "openrelik-worker-plaso.tasks.psort"
 
@@ -68,6 +73,8 @@ def psort(
             "--quiet",
             "--status-view",
             "file",
+            "--additional_fields",
+            "yara_match",
             "--status-view-file",
             status_file.path,
             "-w",
@@ -76,6 +83,7 @@ def psort(
         ]
         command_string = " ".join(command[:5])
 
+        logging.info(f"Running command: {' '.join(command)}")
         process = subprocess.Popen(command)
         while process.poll() is None:
             if not os.path.exists(status_file.path):


### PR DESCRIPTION
Simple PR that adds Yara-scanning capabilities to the log2timeline and psort workers

* log2timeline - takes in a Yara rule file and adds it to the cmdline parameters.
* psort - adds the `yara_match` field to the output CSV.