### PR TITLE
Add volumes flag to log2timeline

### DIFF
--- a/src/log2timeline.py
+++ b/src/log2timeline.py
@@ -130,6 +130,8 @@ def log2timeline(
         "--unattended",
         "--partitions",
         "all",
+        "--volumes",
+        "all",
         "--status-view",
         "file",
         "--status-view-file",


### PR DESCRIPTION
### Summary:
Added volume flag to the log2timeline command to process all available volumes.

### Technical Details:
*   Modified the `log2timeline` function in `src/log2timeline.py` to include the `--volumes all` flag in the command-line arguments passed to the `log2timeline.py` tool. This change ensures that all available volumes and partitions are processed during timeline generation.

Closes #11 