### PR TITLE
feat(plaso): allow setting a custom name for the Plaso output file

### DIFF
--- a/src/log2timeline.py
+++ b/src/log2timeline.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import time
 from uuid import uuid4
+import os
 
 from openrelik_worker_common.file_utils import create_output_file
 from openrelik_worker_common.task_utils import (
@@ -121,28 +122,40 @@ def log2timeline(
     custom_name = None
     if task_config and task_config.get("output_file_name"):
         custom_name = task_config["output_file_name"].strip()
-        if custom_name.endswith(".plaso"):
-            custom_name = custom_name[:-6]
+        # Remove any extension, then add .plaso
+        custom_name = os.path.splitext(custom_name)[0]
+        if not custom_name.lower().endswith(".plaso"):
+            custom_name = f"{custom_name}.plaso"
 
     if len(input_files) == 1:
-        display_name = (
-            f"{custom_name}.plaso"
-            if custom_name
-            else f"{input_files[0].get('display_name')}.plaso"
-        )
-        output_file = create_output_file(
-            output_path,
-            display_name=display_name,
-            data_type="plaso:log2timeline:plaso_storage",
-        )
+        if custom_name:
+            display_name = custom_name
+            output_file = create_output_file(
+                output_path,
+                display_name=display_name,
+                data_type="plaso:log2timeline:plaso_storage",
+            )
+        else:
+            display_name = f"{input_files[0].get('display_name')}"
+            output_file = create_output_file(
+                output_path,
+                display_name=f"{display_name}.plaso",
+                data_type="plaso:log2timeline:plaso_storage",
+            )
     else:
-        display_name = f"{custom_name}.plaso" if custom_name else None
-        output_file = create_output_file(
-            output_path,
-            extension="plaso",
-            display_name=display_name,
-            data_type="plaso:log2timeline:plaso_storage",
-        )
+        if custom_name:
+            display_name = custom_name
+            output_file = create_output_file(
+                output_path,
+                display_name=display_name,
+                data_type="plaso:log2timeline:plaso_storage",
+            )
+        else:
+            output_file = create_output_file(
+                output_path,
+                extension="plaso",
+                data_type="plaso:log2timeline:plaso_storage",
+            )
     status_file = create_output_file(output_path, extension="status")
 
     command = [

--- a/src/log2timeline.py
+++ b/src/log2timeline.py
@@ -85,7 +85,7 @@ TASK_METADATA = {
         {
             "name": "output_file_name",
             "label": "Output file name",
-            "description": "Custom name for the output Plaso file (without extension).",
+            "description": "Custom name for the output Plaso file (without .plaso extension).",
             "type": "text",
             "required": False,
         },
@@ -118,30 +118,22 @@ def log2timeline(
     output_files = []
     temp_dir = None
 
-    # Determine output file name from task_config if provided
+    # Determine display file name from task_config if provided
     custom_name = None
     if task_config and task_config.get("output_file_name"):
-        custom_name = task_config["output_file_name"].strip()
-        # Remove any extension, then add .plaso
-        custom_name = os.path.splitext(custom_name)[0]
+        custom_name = task_config["output_file_name"]
         if not custom_name.lower().endswith(".plaso"):
             custom_name = f"{custom_name}.plaso"
 
     if len(input_files) == 1:
+        display_name=f"{input_files[0].get('display_name')}.plaso"
         if custom_name:
             display_name = custom_name
-            output_file = create_output_file(
-                output_path,
-                display_name=display_name,
-                data_type="plaso:log2timeline:plaso_storage",
-            )
-        else:
-            display_name = f"{input_files[0].get('display_name')}"
-            output_file = create_output_file(
-                output_path,
-                display_name=f"{display_name}.plaso",
-                data_type="plaso:log2timeline:plaso_storage",
-            )
+        output_file = create_output_file(
+            output_path,
+            display_name=display_name,
+            data_type="plaso:log2timeline:plaso_storage",
+        )
     else:
         if custom_name:
             display_name = custom_name

--- a/src/log2timeline.py
+++ b/src/log2timeline.py
@@ -81,6 +81,13 @@ TASK_METADATA = {
             "type": "textarea",
             "required": False,
         },
+        {
+            "name": "output_file_name",
+            "label": "Output file name",
+            "description": "Custom name for the output Plaso file (without extension).",
+            "type": "text",
+            "required": False,
+        },
     ],
 }
 
@@ -110,16 +117,30 @@ def log2timeline(
     output_files = []
     temp_dir = None
 
+    # Determine output file name from task_config if provided
+    custom_name = None
+    if task_config and task_config.get("output_file_name"):
+        custom_name = task_config["output_file_name"].strip()
+        if custom_name.endswith(".plaso"):
+            custom_name = custom_name[:-6]
+
     if len(input_files) == 1:
+        display_name = (
+            f"{custom_name}.plaso"
+            if custom_name
+            else f"{input_files[0].get('display_name')}.plaso"
+        )
         output_file = create_output_file(
             output_path,
-            display_name=f"{input_files[0].get('display_name')}.plaso",
+            display_name=display_name,
             data_type="plaso:log2timeline:plaso_storage",
         )
     else:
+        display_name = f"{custom_name}.plaso" if custom_name else None
         output_file = create_output_file(
             output_path,
             extension="plaso",
+            display_name=display_name,
             data_type="plaso:log2timeline:plaso_storage",
         )
     status_file = create_output_file(output_path, extension="status")


### PR DESCRIPTION
Added the ability to configure a custom name for the Plaso .plaso output file when running the openrelik-worker-plaso task.

Changes include:

- Added a new output_filename configuration field to the task metadata.
- Modified the task logic to honor this field if provided by the user.
- Preserved existing behavior by falling back to a default filename when no name is specified.
- I hope it fits the style and let me know if any changes need to be made.