### PR TITLE
Add optional extraction of single ZIP input (slow $MFT parsing workaround)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     python3-pip \
     python3-poetry \
+    p7zip-full \
     gpg-agent \
     wget \
     tzdata \


### PR DESCRIPTION
### Summary

The changes add a workaround for slow Plaso parsing of $MFT files which reside in a ZIP archive.

### Technical details

- Adds the `p7zip-full` package to the `Dockerfile`, to be able to use the `7z` command for ZIP file extraction.
- Adds an `Extract single ZIP input` configuration option to the `log2timeline` task.
- Adds logic to the `log2timeline` function for extracting single ZIP input to a tempdir using the `extract_archive` function, and passing the tempdir to the  `log2timeline.py` command.

### Background

Plaso parsing of $MFT files is very slow when the $MFT resides in a ZIP archive. Parsing of an $MFT test file (87 MB) takes ~3 minutes, but parsing an $MFT.zip file which contains the same $MFT (nothing else) takes ~73 minutes.

This issue was initially seen when Plaso parsing of triage images created by a Velociraptor offline collector sometimes took up to 4-5 days(!). When the same triage image was extracted to a tempdir and the tempdir was passed to log2timeline.py, the parsing took ~3 hours. When examining the parsing process closely, it was clear that the long tail was always caused by the $MFT file(s) while the other artifacts were parsed reasonably fast.

See also log2timeline/plaso#4999 for more details.